### PR TITLE
Add `Server::run_until` to support graceful shutdown

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -93,14 +93,17 @@ impl Server {
     }
 
     pub fn run(self, addr: &SocketAddr) {
+        self.run_until(addr, futures::future::empty());
+    }
+
+    pub fn run_until<F>(self, addr: &SocketAddr, shutdown_signal: F) where F: Future<Item=(), Error=()> {
         info!(self.log, "Starting server, listening on http://{}", addr);
 
         let a = Arc::new(self);
 
         let server = Http::new().bind(addr, move || Ok(a.clone())).unwrap();
 
-
-        server.run().unwrap();
+        server.run_until(shutdown_signal).unwrap();
     }
 }
 


### PR DESCRIPTION
The `Server::run_until` method uses [`hyper::server::run_until`](https://hyper.rs/hyper/master/hyper/server/struct.Server.html#method.run_until) instead of `run`. This allows you to gracefully shutdown the server.