### PR TITLE
Replace thanks.rust-lang url with hyper::header::Host

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -20,7 +20,7 @@ use futures_cpupool::CpuPool;
 
 use hyper;
 use hyper::StatusCode;
-use hyper::header::{ContentType, Location};
+use hyper::header::{ContentType, Host, Location};
 use hyper::server::{Http, Service};
 
 use handlebars::Handlebars;
@@ -115,9 +115,11 @@ impl Service for Server {
         // from http://jaketrent.com/post/https-redirect-node-heroku/
         if let Some(raw) = req.headers().get_raw("x-forwarded-proto") {
             if raw != &b"https"[..] {
+                let host: &Host = req.headers().get().unwrap();
                 return ::futures::future::ok(
                     hyper::server::Response::new()
-                    .with_header(Location::new(format!("https://thanks.rust-lang.org{}",
+                    .with_header(Location::new(format!("https://{}{}",
+                         host,
                          req.path())))
                     .with_status(StatusCode::MovedPermanently)
                 ).boxed();


### PR DESCRIPTION
This _should_ work. I'm not sure if `let host: &Host = req.headers().get().unwrap();` is the most idiomatic way for getting this value, so code review is more than welcome.