### PR TITLE
Added generics for static strings to improve readability

### DIFF
--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -14,7 +14,7 @@ use serde_json::value::Value;
 
 fn main() {
     let addr = String::from("0.0.0.0:7878").parse().unwrap();
-    let mut server = sparkles::Server::new("templates".to_string());
+    let mut server = sparkles::Server::new("templates");
 
     server.add_route("/", root);
 
@@ -23,7 +23,7 @@ fn main() {
 
 fn root(_: Request) -> BoxFuture<Response, Error> {
     let mut res = ResponseBuilder::new();
-    res.with_template("hello-world".to_string());
+    res.with_template("hello-world");
 
     let name = Value::String(String::from("sparkles"));
     res.data.insert("name".to_string(), name);

--- a/src/response_builder.rs
+++ b/src/response_builder.rs
@@ -17,8 +17,8 @@ impl ResponseBuilder {
         }
     }
 
-    pub fn with_template(&mut self, template: String) {
-        self.template = Some(template);
+    pub fn with_template<S: Into<String>>(&mut self, template: S) {
+        self.template = Some(template.into());
     }
 
     pub fn with_status(&mut self, status: Status) {

--- a/src/server.rs
+++ b/src/server.rs
@@ -39,10 +39,22 @@ pub struct Server {
 }
 
 impl Server {
-    pub fn new(template_root: String) -> Server {
+    /// Construct a `Server`.
+    ///
+    /// Use a path name to create a Server.  The path holds template files used as a view.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # fn run () -> Result <(), sparkles::Error> {
+    /// let mut server = sparkles::Server::new("templates");
+    /// # }
+    /// ```
+    ///
+    pub fn new<S: Into<String>>(template_root: S) -> Server {
         let mut handlebars = Handlebars::new();
 
-        for entry in fs::read_dir(&template_root).unwrap() {
+        for entry in fs::read_dir(&template_root.into()).unwrap() {
             let entry = entry.unwrap();
             let path = entry.path();
             let name = path.file_stem().unwrap().to_str().unwrap();


### PR DESCRIPTION
I find adding `to_string()` to my framework makes the code harder to read.  I propose adding a generic to the methods that take strings as arguments to avoid having these method calls without breaking existing functionality.